### PR TITLE
Update/remove missing apt packages

### DIFF
--- a/docker/php-cli/build/72/Dockerfile
+++ b/docker/php-cli/build/72/Dockerfile
@@ -3,7 +3,6 @@ FROM php:7.2-cli
 RUN rm -rf /var/lib/apt/lists/* && \
     apt-get update && \
     apt-get install --yes \
-    ssmtp \
 	apt-transport-https \
 	lsb-release \
 	ca-certificates \
@@ -18,7 +17,6 @@ RUN apt-get update && apt-get install -y \
     libjpeg62-turbo-dev \
     libpng-dev \
     libicu-dev \
-    libicu57 \
     libsodium-dev \
     libxml2-dev \
     libxml2 \


### PR DESCRIPTION
I had to make the following changes to get the Docker up:
* Remove `ssmtp` package, it is just not found
* Remove the ICU specific package and rely on ICU dev package to bring in the needed dependency

Great project and super helpful, thank you!